### PR TITLE
Bump up to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0 (2017-01-23)
+
+- Change repository name from dockerepos to qcli.
+- Supported only Quay
+
 ## 0.2.0 (2017-01-18)
 
 - list command

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME      := qcli
-VERSION   := v0.2.0
+VERSION   := v0.3.0
 REVISION  := $(shell git rev-parse --short HEAD)
 
 SRCS      := $(shell find . -name '*.go' -type f)


### PR DESCRIPTION
## WHY

Bump up to v0.3.0

- Change repository name
- add prefix
